### PR TITLE
[STUDIO-7375] Disable leak password detection for Chrome browser

### DIFF
--- a/settings/internal/com.kms.katalon.core.webui.chrome (headless).properties
+++ b/settings/internal/com.kms.katalon.core.webui.chrome (headless).properties
@@ -1,0 +1,1 @@
+{"HEADLESS_DRIVER":{"prefs":{"profile.password_manager_leak_detection":false}}}

--- a/settings/internal/com.kms.katalon.core.webui.chrome.properties
+++ b/settings/internal/com.kms.katalon.core.webui.chrome.properties
@@ -1,0 +1,1 @@
+{"CHROME_DRIVER":{"prefs":{"profile.password_manager_leak_detection":false}}}


### PR DESCRIPTION
### Description

- Add project WebUI Chrome settings `"prefs":{"profile.password_manager_leak_detection":false}` to disable password security popup for web test project

### References

[STUDIO-7375](https://katalon.atlassian.net/browse/STUDIO-7375)

[STUDIO-7375]: https://katalon.atlassian.net/browse/STUDIO-7375?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ